### PR TITLE
Copy photo description from 'Other' field (i.e. EXIF data)

### DIFF
--- a/src/gptk-core.js
+++ b/src/gptk-core.js
@@ -392,6 +392,6 @@ export default class Core {
     if (action.elementId === 'unArchive') await this.apiUtils.unArchive(mediaItems);
     if (action.elementId === 'toFavorite') await this.apiUtils.setAsFavorite(mediaItems);
     if (action.elementId === 'unFavorite') await this.apiUtils.unFavorite(mediaItems);
-    if (action.elementId === 'setDescToOther') await this.apiUtils.setDescriptionToOther(mediaItems);
+    if (action.elementId === 'copyDescFromOther') await this.apiUtils.copyDescriptionFromOther(mediaItems);
   }
 }

--- a/src/gptk-core.js
+++ b/src/gptk-core.js
@@ -392,5 +392,6 @@ export default class Core {
     if (action.elementId === 'unArchive') await this.apiUtils.unArchive(mediaItems);
     if (action.elementId === 'toFavorite') await this.apiUtils.setAsFavorite(mediaItems);
     if (action.elementId === 'unFavorite') await this.apiUtils.unFavorite(mediaItems);
+    if (action.elementId === 'setDescToOther') await this.apiUtils.setDescriptionToOther(mediaItems);
   }
 }

--- a/src/ui/logic/action-bar.js
+++ b/src/ui/logic/action-bar.js
@@ -23,6 +23,7 @@ const actions = [
   { elementId: 'unFavorite' },
   { elementId: 'lock' },
   { elementId: 'unLock' },
+  { elementId: 'setDescToOther' },
 ];
 
 function userConfirmation(action, filter, source) {

--- a/src/ui/logic/action-bar.js
+++ b/src/ui/logic/action-bar.js
@@ -23,7 +23,7 @@ const actions = [
   { elementId: 'unFavorite' },
   { elementId: 'lock' },
   { elementId: 'unLock' },
-  { elementId: 'setDescToOther' },
+  { elementId: 'copyDescFromOther' },
 ];
 
 function userConfirmation(action, filter, source) {

--- a/src/ui/logic/advanced-settings.js
+++ b/src/ui/logic/advanced-settings.js
@@ -20,13 +20,15 @@ export default function advancedSettingsListenersSetUp() {
     saveToStorage('apiSettings', apiSettingsDefault);
 
     // Update the form with default values
-    maxConcurrentApiReqInput.value = apiSettingsDefault.maxConcurrentApiReq;
+    maxConcurrentSingleApiReqInput.value = apiSettingsDefault.maxConcurrentSingleApiReq;
+    maxConcurrentBatchApiReqInput.value = apiSettingsDefault.maxConcurrentBatchApiReq;
     operationSizeInput.value = apiSettingsDefault.operationSize;
     lockedFolderOpSizeInput.value = apiSettingsDefault.lockedFolderOpSize;
     infoSizeInput.value = apiSettingsDefault.infoSize;
     log('Default api settings restored');
   }
-  const maxConcurrentApiReqInput = document.querySelector('input[name="maxConcurrentApiReq"]');
+  const maxConcurrentSingleApiReqInput = document.querySelector('input[name="maxConcurrentSingleApiReq"]');
+  const maxConcurrentBatchApiReqInput = document.querySelector('input[name="maxConcurrentBatchApiReq"]');
   const operationSizeInput = document.querySelector('input[name="operationSize"]');
   const lockedFolderOpSizeInput = document.querySelector('input[name="lockedFolderOpSize"]');
   const infoSizeInput = document.querySelector('input[name="infoSize"]');
@@ -35,7 +37,10 @@ export default function advancedSettingsListenersSetUp() {
 
   const restoredSettings = getFromStorage('apiSettings');
 
-  maxConcurrentApiReqInput.value = restoredSettings?.maxConcurrentApiReq || apiSettingsDefault.maxConcurrentApiReq;
+  maxConcurrentSingleApiReqInput.value =
+    restoredSettings?.maxConcurrentSingleApiReq || apiSettingsDefault.maxConcurrentSingleApiReq;
+  maxConcurrentBatchApiReqInput.value =
+    restoredSettings?.maxConcurrentBatchApiReq || apiSettingsDefault.maxConcurrentBatchApiReq;
   operationSizeInput.value = restoredSettings?.operationSize || apiSettingsDefault.operationSize;
   lockedFolderOpSizeInput.value = restoredSettings?.lockedFolderOpSize || apiSettingsDefault.lockedFolderOpSize;
   infoSizeInput.value = restoredSettings?.infoSize || apiSettingsDefault.infoSize;

--- a/src/ui/logic/update-state.js
+++ b/src/ui/logic/update-state.js
@@ -46,6 +46,7 @@ export function updateUI() {
     document.getElementById('toTrash').disabled = isActiveTab('trash');
     document.getElementById('lock').disabled = isActiveTab('lockedFolder');
     document.getElementById('unLock').disabled = !isActiveTab('lockedFolder');
+    document.getElementById('setDescToOther').disabled = isActiveTab('trash');
   }
 
   function updateFilterVisibility() {

--- a/src/ui/logic/update-state.js
+++ b/src/ui/logic/update-state.js
@@ -46,7 +46,7 @@ export function updateUI() {
     document.getElementById('toTrash').disabled = isActiveTab('trash');
     document.getElementById('lock').disabled = isActiveTab('lockedFolder');
     document.getElementById('unLock').disabled = !isActiveTab('lockedFolder');
-    document.getElementById('setDescToOther').disabled = isActiveTab('trash');
+    document.getElementById('copyDescFromOther').disabled = isActiveTab('trash');
   }
 
   function updateFilterVisibility() {

--- a/src/ui/markup/gptk-main-template.html
+++ b/src/ui/markup/gptk-main-template.html
@@ -91,7 +91,7 @@
       <button type="button" id="unFavorite" title="Removed From Favorites">Un-Favorite</button>
       <button type="button" id="lock" title="Move to Locked Folder">Move to Locked Folder</button>
       <button type="button" id="unLock" title="Move out of Locked Folder">Move out of Locked Folder</button>
-      <button type="button" id="setDescToOther" title="Set Empty Description to 'Other' Field">Set Description to Other</button>
+      <button type="button" id="copyDescFromOther" title="Copy Description from 'Other' Field">Copy Description from 'Other'</button>
     </div>
 
     <div class="to-existing-container">

--- a/src/ui/markup/gptk-main-template.html
+++ b/src/ui/markup/gptk-main-template.html
@@ -91,6 +91,7 @@
       <button type="button" id="unFavorite" title="Removed From Favorites">Un-Favorite</button>
       <button type="button" id="lock" title="Move to Locked Folder">Move to Locked Folder</button>
       <button type="button" id="unLock" title="Move out of Locked Folder">Move out of Locked Folder</button>
+      <button type="button" id="setDescToOther" title="Set Empty Description to 'Other' Field">Set Description to Other</button>
     </div>
 
     <div class="to-existing-container">
@@ -439,9 +440,13 @@
         <details class="settings">
           <summary>Advanced Settings</summary>
           <fieldset>
-            <legend>Max Concurrent Api Requests</legend>
+            <legend>Max Concurrent Single Api Requests</legend>
             <div class="input-wrapper">
-              <input name="maxConcurrentApiReq" value="3" min="1" type="number" required>
+              <input name="maxConcurrentSingleApiReq" value="30" min="1" type="number" required>
+            </div>
+            <legend>Max Concurrent Batch Api Requests</legend>
+            <div class="input-wrapper">
+              <input name="maxConcurrentBatchApiReq" value="3" min="1" type="number" required>
             </div>
             <legend>Api Operation Batch Size</legend>
             <div class="input-wrapper">


### PR DESCRIPTION
Added an action that copies captions embedded in the photos themselves (i.e. EXIF data) to the photo description. Such captions otherwise only show up in the Info tab as "Other". This feature can be useful for photos imported from Picasa, Photoshop, etc.