### PR TITLE
Fixed two rendering issues with album selection on Chrome+MacOS

### DIFF
--- a/src/ui/markup/style.css
+++ b/src/ui/markup/style.css
@@ -165,6 +165,12 @@
         background-color: var(--color-accent-dark);
     }
 
+    option:checked {
+        background-color: #007bff; /* A distinct blue */
+        color: white;
+        font-weight: bold;
+    }
+    
     hr {
         border: none;
         margin: 0px;
@@ -310,7 +316,8 @@
         }
 
         fieldset {
-            display: flex;
+            /* display: flex; */
+            /* (causes inconsistent rendering of the album selection fieldsets) */
             flex-direction: column;
             margin: 0 20px;
             padding-left: 20px;


### PR DESCRIPTION
1. Selection box would often initially render with zero height (no albums visible).
2. Selected albums looked identical to unselected albums.  Now they have a blue background (at least on Chrome/MacOS).
<select> blocks aren't rendered consistently across browsers/operating systems, but this change fixes the problems I was seeing on Chrome and MacOS.
