### PR TITLE
Fix moveItemsToTrash API - add mediaKey parameter

### DIFF
--- a/src/api/api-utils.js
+++ b/src/api/api-utils.js
@@ -120,8 +120,9 @@ export default class ApiUtils {
 
   async moveToTrash(mediaItems) {
     log(`Moving ${mediaItems.length} items to trash`);
-    const dedupKeyArray = mediaItems.map((item) => item.dedupKey);
-    await this.executeWithConcurrency(this.api.moveItemsToTrash, this.operationSize, dedupKeyArray);
+    // Pass full mediaItems so we can extract both dedupKey and mediaKey in the API call
+    const itemPairs = mediaItems.map((item) => ({ dedupKey: item.dedupKey, mediaKey: item.mediaKey }));
+    await this.executeWithConcurrency(this.api.moveItemsToTrashBatch, this.operationSize, itemPairs);
   }
 
   async restoreFromTrash(trashItems) {

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -176,18 +176,39 @@ export default class Api {
     }
   }
 
-  async moveItemsToTrash(dedupKeyArray) {
+  async moveItemsToTrash(dedupKeyArray, mediaKeyArray = null) {
     // type assertion
     if (dedupKeyArray) assertInstance(dedupKeyArray, Array);
 
     const rpcid = 'XwAOJf';
-    const requestData = [null, 1, dedupKeyArray, 3];
+    const requestData = [null, 1, dedupKeyArray, 3, null, mediaKeyArray];
     // note: It seems that '3' here corresponds to items' location
     try {
       const response = await this.makeApiRequest(rpcid, requestData);
       return response[0];
     } catch (error) {
       console.error('Error in moveItemsToTrash:', error);
+      throw error;
+    }
+  }
+
+  async moveItemsToTrashBatch(itemPairs) {
+    // itemPairs is an array of {dedupKey, mediaKey} objects
+    // type assertion
+    if (itemPairs) assertInstance(itemPairs, Array);
+
+    const dedupKeyArray = itemPairs.map(item => item.dedupKey);
+    const mediaKeyArray = itemPairs.map(item => item.mediaKey);
+
+    const rpcid = 'XwAOJf';
+    const requestData = [null, 1, dedupKeyArray, 3, null, mediaKeyArray];
+    // note: It seems that '3' here corresponds to items' location
+    // Google now requires mediaKeys as 5th parameter (after null)
+    try {
+      const response = await this.makeApiRequest(rpcid, requestData);
+      return response[0];
+    } catch (error) {
+      console.error('Error in moveItemsToTrashBatch:', error);
       throw error;
     }
   }


### PR DESCRIPTION
Google Photos API now requires mediaKey array as 5th parameter in delete requests. Without it, the API returns undefined causing "undefined is not valid JSON" errors.

Changes:
- Added moveItemsToTrashBatch() function in api.js that includes both dedupKey and mediaKey arrays in the request
- Updated moveToTrash() in api-utils.js to extract and pass both dedupKey and mediaKey from media items
- Request format changed from [null, 1, dedupKeys, 3] to [null, 1, dedupKeys, 3, null, mediaKeys]

Fixes delete functionality broken by Google Photos internal API changes in October 2025.

Tested and confirmed working with current Google Photos API.