### PR TITLE
feat: add video duration filter (closes #116)

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -199,6 +199,22 @@ export function filterArchived(mediaItems: MediaItem[], filter: Filter): MediaIt
   return result;
 }
 
+export function filterByDuration(mediaItems: MediaItem[], filter: Filter): MediaItem[] {
+  log('Filtering by duration');
+  let result = mediaItems;
+  const minSec = parseFloat(filter.minDuration ?? '');
+  const maxSec = parseFloat(filter.maxDuration ?? '');
+  // duration on MediaItem is in milliseconds
+  if (!isNaN(minSec)) {
+    result = result.filter((item) => item.duration !== undefined && item.duration >= minSec * 1000);
+  }
+  if (!isNaN(maxSec)) {
+    result = result.filter((item) => item.duration !== undefined && item.duration <= maxSec * 1000);
+  }
+  log(`Item count after filtering: ${result.length}`);
+  return result;
+}
+
 // Process images in batches with yield points
 async function processBatch<T, R>(
   items: T[],

--- a/src/gptk-core.ts
+++ b/src/gptk-core.ts
@@ -208,6 +208,11 @@ export default class Core {
         condition: Boolean(filter.minWidth ?? filter.maxWidth ?? filter.minHeight ?? filter.maxHeight),
         method: () => filters.resolutionFilter(filteredItems, filter),
       },
+      {
+        // duration is available from the basic timeline response — no extended info needed
+        condition: Boolean(filter.minDuration ?? filter.maxDuration),
+        method: () => filters.filterByDuration(filteredItems, filter),
+      },
     ];
 
     // Apply basic filters
@@ -432,6 +437,11 @@ export default class Core {
     const maxH = parseInt(filter.maxHeight ?? '0');
     if (minH > 0 && maxH > 0 && minH >= maxH) {
       throw new Error('Invalid Resolution Filter: Min Height must be less than Max Height');
+    }
+    const minDur = parseFloat(filter.minDuration ?? '');
+    const maxDur = parseFloat(filter.maxDuration ?? '');
+    if (!isNaN(minDur) && !isNaN(maxDur) && minDur >= maxDur) {
+      throw new Error('Invalid Duration Filter: Min Duration must be less than Max Duration');
     }
     const bS = parseFloat(filter.boundSouth ?? '');
     const bW = parseFloat(filter.boundWest ?? '');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,7 +94,7 @@ export interface Actor {
   gaiaId?: string;
   name?: string;
   gender?: string;
-  profilePhotoUrl?: string;  // Fixed typo: was "profiePhotoUrl"
+  profilePhotoUrl?: string; // Fixed typo: was "profiePhotoUrl"
 }
 
 // ============================================================
@@ -147,7 +147,7 @@ export interface PartnerSharedItemsPage {
   nextPageId?: string;
   items?: PartnerSharedItem[];
   members?: Actor[];
-  partnerActorId?: string;  // Fixed typo: was "parnterActorId"
+  partnerActorId?: string; // Fixed typo: was "parnterActorId"
   gaiaId?: string;
 }
 
@@ -265,8 +265,8 @@ export interface RemoteMatch {
 // ============================================================
 
 export interface Filter {
-  dateType?: 'taken' | 'uploaded';
-  intervalType?: 'include' | 'exclude';
+  dateType?: "taken" | "uploaded";
+  intervalType?: "include" | "exclude";
   lowerBoundaryDate?: string;
   higherBoundaryDate?: string;
   lowerBoundarySize?: string;
@@ -275,23 +275,23 @@ export interface Filter {
   maxWidth?: string;
   minHeight?: string;
   maxHeight?: string;
-  type?: 'video' | 'image' | 'live';
-  quality?: 'original' | 'storage-saver';
-  space?: 'consuming' | 'non-consuming';
-  owned?: 'true' | 'false';
-  archived?: 'true' | 'false';
-  favorite?: 'true' | 'false';
+  type?: "video" | "image" | "live";
+  quality?: "original" | "storage-saver";
+  space?: "consuming" | "non-consuming";
+  owned?: "true" | "false";
+  archived?: "true" | "false";
+  favorite?: "true" | "false";
   excludeFavorites?: string;
-  hasLocation?: 'true' | 'false';
+  hasLocation?: "true" | "false";
   boundSouth?: string;
   boundWest?: string;
   boundNorth?: string;
   boundEast?: string;
-  uploadStatus?: 'full' | 'partial';
+  uploadStatus?: "full" | "partial";
   fileNameRegex?: string;
-  fileNameMatchType?: 'include' | 'exclude';
+  fileNameMatchType?: "include" | "exclude";
   descriptionRegex?: string;
-  descriptionMatchType?: 'include' | 'exclude';
+  descriptionMatchType?: "include" | "exclude";
   albumsInclude?: string | string[];
   albumsExclude?: string | string[];
   excludeShared?: string;
@@ -299,9 +299,20 @@ export interface Filter {
   similarityThreshold?: string;
   imageHeight?: string;
   sortBySize?: string;
+  /** Minimum video duration in seconds (videos shorter than this are excluded). */
+  minDuration?: string;
+  /** Maximum video duration in seconds (videos longer than this are excluded). */
+  maxDuration?: string;
 }
 
-export type Source = 'library' | 'search' | 'trash' | 'lockedFolder' | 'favorites' | 'sharedLinks' | 'albums';
+export type Source =
+  | "library"
+  | "search"
+  | "trash"
+  | "lockedFolder"
+  | "favorites"
+  | "sharedLinks"
+  | "albums";
 
 // ============================================================
 // API Settings Types
@@ -331,7 +342,7 @@ export interface Action {
 export interface WindowGlobalData {
   rapt?: unknown;
   account: string;
-  'f.sid': string;
+  "f.sid": string;
   bl: string;
   path: string;
   at: string;

--- a/tests/filters.test.ts
+++ b/tests/filters.test.ts
@@ -11,6 +11,7 @@ import {
   filterOwned,
   filterByUploadStatus,
   filterArchived,
+  filterByDuration,
   hammingDistance,
   calculateHashSize,
 } from '../src/filters';
@@ -359,6 +360,57 @@ describe('filterArchived', () => {
   it('filters non-archived items', () => {
     const result = filterArchived(items, makeFilter({ archived: 'false' }));
     // isArchived !== true → false and undefined
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ─── filterByDuration ───────────────────────────────────────────────
+
+describe('filterByDuration', () => {
+  // duration on MediaItem is stored in milliseconds
+  const items = [
+    makeItem({ duration: 5_000 }),   //  5 s
+    makeItem({ duration: 30_000 }),  // 30 s
+    makeItem({ duration: 60_000 }),  // 60 s
+    makeItem({ duration: 120_000 }), // 120 s
+    makeItem({ duration: undefined }),// image — no duration
+  ];
+
+  it('filters videos longer than minDuration (in seconds)', () => {
+    const result = filterByDuration(items, makeFilter({ minDuration: '30' }));
+    // 30 s, 60 s, and 120 s qualify (>= 30 s); 5 s and undefined are excluded
+    expect(result).toHaveLength(3);
+    expect(result.every((i) => (i.duration ?? 0) >= 30_000)).toBe(true);
+  });
+
+  it('filters videos shorter than maxDuration (in seconds)', () => {
+    const result = filterByDuration(items, makeFilter({ maxDuration: '60' }));
+    // 5 s and 30 s and 60 s qualify (<= 60 s); 120 s and undefined are excluded
+    expect(result).toHaveLength(3);
+    expect(result.every((i) => (i.duration ?? Infinity) <= 60_000)).toBe(true);
+  });
+
+  it('applies both minDuration and maxDuration together', () => {
+    const result = filterByDuration(items, makeFilter({ minDuration: '10', maxDuration: '90' }));
+    // 30 s and 60 s qualify; 5 s, 120 s, and undefined are excluded
+    expect(result).toHaveLength(2);
+    expect(result.map((i) => i.duration)).toEqual([30_000, 60_000]);
+  });
+
+  it('excludes items with no duration (images) when minDuration is set', () => {
+    const result = filterByDuration(items, makeFilter({ minDuration: '1' }));
+    expect(result.every((i) => i.duration !== undefined)).toBe(true);
+  });
+
+  it('returns all items when neither minDuration nor maxDuration is set', () => {
+    const result = filterByDuration(items, makeFilter({}));
+    expect(result).toHaveLength(5);
+  });
+
+  it('handles fractional seconds (e.g. 0.5 s)', () => {
+    const shortClips = [makeItem({ duration: 400 }), makeItem({ duration: 600 }), makeItem({ duration: 1000 })];
+    const result = filterByDuration(shortClips, makeFilter({ minDuration: '0.5' }));
+    // 400 ms = 0.4 s → excluded; 600 ms = 0.6 s, 1000 ms = 1 s → included
     expect(result).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

Implements the feature requested in #116 — the ability to find videos with a duration longer or shorter than a given length.

## Changes

### src/types/index.ts
Added two new optional fields to the Filter interface:
- minDuration?: string — minimum video duration in **seconds** (excludes shorter videos)
- maxDuration?: string — maximum video duration in **seconds** (excludes longer videos)

Using a string type is consistent with the existing lowerBoundarySize, maxWidth, etc. fields.

### src/filters.ts
Added ilterByDuration(mediaItems, filter):
- Parses minDuration / maxDuration as floats (supports fractional seconds, e.g. 