### PR TITLE
Add video duration filter

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -51,6 +51,23 @@ export function resolutionFilter(mediaItems: MediaItem[], filter: Filter): Media
   return result;
 }
 
+export function durationFilter(mediaItems: MediaItem[], filter: Filter): MediaItem[] {
+  log('Filtering by duration');
+  let result = mediaItems;
+  const minDuration = parseFloat(filter.minDuration ?? '');
+  const maxDuration = parseFloat(filter.maxDuration ?? '');
+
+  if (!isNaN(minDuration)) {
+    result = result.filter((item) => item.duration !== undefined && item.duration >= minDuration * 1000);
+  }
+  if (!isNaN(maxDuration)) {
+    result = result.filter((item) => item.duration !== undefined && item.duration <= maxDuration * 1000);
+  }
+
+  log(`Item count after filtering: ${result.length}`);
+  return result;
+}
+
 export function qualityFilter(mediaItems: MediaItem[], filter: Filter): MediaItem[] {
   log('Filtering by quality');
   let result = mediaItems;

--- a/src/gptk-core.ts
+++ b/src/gptk-core.ts
@@ -214,6 +214,10 @@ export default class Core {
         condition: Boolean(filter.minWidth ?? filter.maxWidth ?? filter.minHeight ?? filter.maxHeight),
         method: () => filters.resolutionFilter(filteredItems, filter),
       },
+      {
+        condition: Boolean(filter.minDuration ?? filter.maxDuration),
+        method: () => filters.durationFilter(filteredItems, filter),
+      },
     ];
 
     // Apply basic filters
@@ -438,6 +442,17 @@ export default class Core {
     const maxH = parseInt(filter.maxHeight ?? '0');
     if (minH > 0 && maxH > 0 && minH >= maxH) {
       throw new Error('Invalid Resolution Filter: Min Height must be less than Max Height');
+    }
+    const minDuration = parseFloat(filter.minDuration ?? '');
+    const maxDuration = parseFloat(filter.maxDuration ?? '');
+    if (!isNaN(minDuration) && minDuration < 0) {
+      throw new Error('Invalid Duration Filter: Min Duration must not be negative');
+    }
+    if (!isNaN(maxDuration) && maxDuration < 0) {
+      throw new Error('Invalid Duration Filter: Max Duration must not be negative');
+    }
+    if (!isNaN(minDuration) && !isNaN(maxDuration) && minDuration >= maxDuration) {
+      throw new Error('Invalid Duration Filter: Min Duration must be less than Max Duration');
     }
     const bS = parseFloat(filter.boundSouth ?? '');
     const bW = parseFloat(filter.boundWest ?? '');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -277,6 +277,8 @@ export interface Filter {
   maxWidth?: string;
   minHeight?: string;
   maxHeight?: string;
+  minDuration?: string;
+  maxDuration?: string;
   type?: 'video' | 'image' | 'live';
   quality?: 'original' | 'storage-saver';
   space?: 'consuming' | 'non-consuming';

--- a/src/ui/logic/filter-description-gen.ts
+++ b/src/ui/logic/filter-description-gen.ts
@@ -6,6 +6,10 @@ function parseSize(value?: string): number {
   return parseInt(value ?? '0', 10);
 }
 
+function parseNumber(value?: string): number {
+  return parseFloat(value ?? '');
+}
+
 function formatDate(value?: string): string | null {
   return value ? new Date(value).toLocaleString('en-GB') : null;
 }
@@ -128,6 +132,19 @@ const rules: DescriptionRule[] = [
     },
   },
 
+  // duration range
+  {
+    test: (f) => !isNaN(parseNumber(f.minDuration)) || !isNaN(parseNumber(f.maxDuration)),
+    describe: (f) => {
+      const minDuration = parseNumber(f.minDuration);
+      const maxDuration = parseNumber(f.maxDuration);
+      const parts: string[] = [];
+      if (!isNaN(minDuration)) parts.push(`duration >= ${minDuration}s`);
+      if (!isNaN(maxDuration)) parts.push(`duration <= ${maxDuration}s`);
+      return `with ${parts.join(', ')}`;
+    },
+  },
+
   // size range
   {
     test: (f) => parseSize(f.lowerBoundarySize) > 0 || parseSize(f.higherBoundarySize) > 0,
@@ -223,6 +240,18 @@ function validate(filter: Filter): string | null {
   const maxH = parseSize(filter.maxHeight);
   if (minH > 0 && maxH > 0 && minH >= maxH) {
     return 'Error: Invalid Resolution Filter (Height)';
+  }
+
+  const minDuration = parseNumber(filter.minDuration);
+  const maxDuration = parseNumber(filter.maxDuration);
+  if (!isNaN(minDuration) && minDuration < 0) {
+    return 'Error: Invalid Duration Filter (Min)';
+  }
+  if (!isNaN(maxDuration) && maxDuration < 0) {
+    return 'Error: Invalid Duration Filter (Max)';
+  }
+  if (!isNaN(minDuration) && !isNaN(maxDuration) && minDuration >= maxDuration) {
+    return 'Error: Invalid Duration Filter';
   }
 
   return null;

--- a/src/ui/markup/gptk-main-template.html
+++ b/src/ui/markup/gptk-main-template.html
@@ -205,6 +205,11 @@
           <legend>Max Height</legend><div class="input-wrapper"><input name="maxHeight" type="number" placeholder="Pixels"></div>
         </fieldset></details>
 
+        <details class="duration"><summary>Duration</summary><fieldset>
+          <legend>Min Duration</legend><div class="input-wrapper"><input name="minDuration" type="number" min="0" step="0.1" placeholder="Seconds"></div>
+          <legend>Max Duration</legend><div class="input-wrapper"><input name="maxDuration" type="number" min="0" step="0.1" placeholder="Seconds"></div>
+        </fieldset></details>
+
         <details class="quality"><summary>Quality</summary><fieldset><div class="radio-group">
           <label class="form-control"><input name="quality" value="" type="radio" checked="checked"> Any</label>
           <label class="form-control"><input name="quality" value="original" type="radio"> Original</label>


### PR DESCRIPTION
## Summary

Adds a `Duration` filter with min/max duration inputs in seconds.

The filter uses the existing `MediaItem.duration` field, which is stored in milliseconds, and excludes non-video items when a duration bound is active. The selected range is also included in the action confirmation summary.

Closes #116.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`

Regression tests not run per repository instruction.