### PR TITLE
Use hide icon for toolbar button

### DIFF
--- a/src/ui/markup/gptk-main-template.html
+++ b/src/ui/markup/gptk-main-template.html
@@ -18,8 +18,8 @@
       <span class="step-arrow">&rarr;</span>
       <span class="step-badge">3</span> Action
     </div>
-    <div id="hide" title="Close">
-      <svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 -960 960 960" width="18"><path d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z"/></svg>
+    <div id="hide" title="Hide">
+      <svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 -960 960 960" width="18"><path d="M480-345 240-585l56-56 184 184 184-184 56 56-240 240Z"/></svg>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- Replaces the top-bar X icon with a chevron-style hide icon.
- Updates the top-bar control title from `Close` to `Hide` to match the actual behavior.

## Verification

- `pnpm run typecheck`
- `pnpm run lint` (passes with existing warnings)
- `pnpm run build`

Regression tests not run per repository instruction.