### PR TITLE
feat: add Remove from Album action

### DIFF
--- a/src/api/api-utils.ts
+++ b/src/api/api-utils.ts
@@ -214,18 +214,36 @@ export default class ApiUtils {
   }
 
   /**
-   * Removes items from their album without trashing them.
+   * Removes items from their album(s) without trashing them.
    *
    * Only valid for items fetched via the Albums source: their album-scoped
-   * `mediaKey` (from getAlbumPage) is the key the removal RPC expects — not
-   * the library dedupKey. Sent in configured batches.
+   * `mediaKey` (from getAlbumPage) is the key the removal RPCs expect — not
+   * the library dedupKey. Items are grouped by source album and routed to the
+   * shared- or regular-album RPC, then sent in configured batches.
    *
    * @param mediaItems - The album items to remove.
    */
   async removeFromAlbum(mediaItems: MediaItem[]): Promise<void> {
     log(`Removing ${mediaItems.length} items from album`);
-    const itemAlbumMediaKeyArray = mediaItems.map((item) => item.mediaKey);
-    await this.executeWithConcurrency(this.api.removeItemsFromAlbum.bind(this.api), this.operationSize, itemAlbumMediaKeyArray);
+
+    const itemsByAlbum = new Map<string, MediaItem[]>();
+    for (const item of mediaItems) {
+      const albumKey = item.sourceAlbumMediaKey ?? '';
+      const group = itemsByAlbum.get(albumKey);
+      if (group) group.push(item);
+      else itemsByAlbum.set(albumKey, [item]);
+    }
+
+    for (const [albumMediaKey, items] of itemsByAlbum) {
+      const itemMediaKeys = items.map((item) => item.mediaKey);
+      if (items[0]?.sourceAlbumIsShared) {
+        // Shared albums use a different RPC that also needs the album key.
+        const removeFromShared = (chunk: string[]): Promise<unknown> => this.api.removeItemsFromSharedAlbum(albumMediaKey, chunk);
+        await this.executeWithConcurrency(removeFromShared, this.operationSize, itemMediaKeys);
+      } else {
+        await this.executeWithConcurrency(this.api.removeItemsFromAlbum.bind(this.api), this.operationSize, itemMediaKeys);
+      }
+    }
   }
 
   async sendToArchive(mediaItems: MediaItem[]): Promise<void> {

--- a/src/api/api-utils.ts
+++ b/src/api/api-utils.ts
@@ -213,6 +213,21 @@ export default class ApiUtils {
     await this.executeWithConcurrency(this.api.restoreFromTrash.bind(this.api), this.operationSize, dedupKeyArray);
   }
 
+  /**
+   * Removes items from their album without trashing them.
+   *
+   * Only valid for items fetched via the Albums source: their album-scoped
+   * `mediaKey` (from getAlbumPage) is the key the removal RPC expects — not
+   * the library dedupKey. Sent in configured batches.
+   *
+   * @param mediaItems - The album items to remove.
+   */
+  async removeFromAlbum(mediaItems: MediaItem[]): Promise<void> {
+    log(`Removing ${mediaItems.length} items from album`);
+    const itemAlbumMediaKeyArray = mediaItems.map((item) => item.mediaKey);
+    await this.executeWithConcurrency(this.api.removeItemsFromAlbum.bind(this.api), this.operationSize, itemAlbumMediaKeyArray);
+  }
+
   async sendToArchive(mediaItems: MediaItem[]): Promise<void> {
     log(`Sending ${mediaItems.length} items to archive`);
     const filtered = mediaItems.filter((item) => item?.isArchived !== true);

--- a/src/gptk-core.ts
+++ b/src/gptk-core.ts
@@ -2,6 +2,7 @@ import Api from './api/api';
 import ApiUtils from './api/api-utils';
 import { timeToHHMMSS, isPatternValid } from './utils/helpers';
 import log from './ui/logic/log';
+import getFromStorage from './utils/getFromStorage';
 import * as filters from './filters';
 import { apiSettingsDefault } from './api/api-utils-default-presets';
 import type { MediaItem, Filter, Source, Action, Album, ApiSettings, LibraryTimelinePage } from './types';
@@ -112,6 +113,7 @@ export default class Core {
           throw new Error('no target album');
         }
         const albumMediaKeys = Array.isArray(filter.albumsInclude) ? filter.albumsInclude : [filter.albumsInclude];
+        const sharedByAlbumKey = new Map((getFromStorage<Album[]>('albums') ?? []).map((album) => [album.mediaKey, album.isShared ?? false]));
         const albumItems = await Promise.all(
           albumMediaKeys.map(async (albumMediaKey) => {
             log('Getting album items');
@@ -120,6 +122,7 @@ export default class Core {
               ...item,
               sourceAlbumMediaKey: albumMediaKey,
               sourceAlbumTitle: albumTitle,
+              sourceAlbumIsShared: sharedByAlbumKey.get(albumMediaKey) ?? false,
             }));
           })
         );

--- a/src/gptk-core.ts
+++ b/src/gptk-core.ts
@@ -112,12 +112,16 @@ export default class Core {
           throw new Error('no target album');
         }
         const albumMediaKeys = Array.isArray(filter.albumsInclude) ? filter.albumsInclude : [filter.albumsInclude];
-        const sharedByAlbumKey = new Map((getFromStorage<Album[]>('albums') ?? []).map((album) => [album.mediaKey, album.isShared ?? false]));
-        // Cached album metadata can be missing or stale; fetch fresh so shared albums route to the shared-album RPC.
+        // Only trust a known boolean isShared; a missing value (stale/old cache) stays unknown so the fetch below resolves it.
+        const sharedByAlbumKey = new Map<string, boolean>(
+          (getFromStorage<Album[]>('albums') ?? [])
+            .filter((album) => typeof album.isShared === 'boolean')
+            .map((album) => [album.mediaKey, album.isShared as boolean])
+        );
         if (albumMediaKeys.some((albumMediaKey) => !sharedByAlbumKey.has(albumMediaKey))) {
           const albums = await this.apiUtils.getAllAlbums();
           for (const album of albums) {
-            sharedByAlbumKey.set(album.mediaKey, album.isShared ?? false);
+            if (typeof album.isShared === 'boolean') sharedByAlbumKey.set(album.mediaKey, album.isShared);
           }
         }
         const albumItems = await Promise.all(

--- a/src/gptk-core.ts
+++ b/src/gptk-core.ts
@@ -114,6 +114,13 @@ export default class Core {
         }
         const albumMediaKeys = Array.isArray(filter.albumsInclude) ? filter.albumsInclude : [filter.albumsInclude];
         const sharedByAlbumKey = new Map((getFromStorage<Album[]>('albums') ?? []).map((album) => [album.mediaKey, album.isShared ?? false]));
+        // Cached album metadata can be missing or stale; fetch fresh so shared albums route to the shared-album RPC.
+        if (albumMediaKeys.some((albumMediaKey) => !sharedByAlbumKey.has(albumMediaKey))) {
+          const albums = await this.apiUtils.getAllAlbums();
+          for (const album of albums) {
+            sharedByAlbumKey.set(album.mediaKey, album.isShared ?? false);
+          }
+        }
         const albumItems = await Promise.all(
           albumMediaKeys.map(async (albumMediaKey) => {
             log('Getting album items');

--- a/src/gptk-core.ts
+++ b/src/gptk-core.ts
@@ -40,6 +40,13 @@ export default class Core {
         await this.apiUtils.addToNewAlbum(p.mediaItems, p.newTargetAlbumName, p.preserveOrder);
       },
       toTrash: async (p) => this.apiUtils.moveToTrash(p.mediaItems),
+      removeFromAlbum: async (p) => {
+        if (p.source !== 'albums') {
+          log('Remove from album requires the Albums source', 'error');
+          return;
+        }
+        await this.apiUtils.removeFromAlbum(p.mediaItems);
+      },
       toArchive: async (p) => this.apiUtils.sendToArchive(p.mediaItems),
       unArchive: async (p) => this.apiUtils.unArchive(p.mediaItems),
       toFavorite: async (p) => this.apiUtils.setAsFavorite(p.mediaItems),

--- a/src/gptk-core.ts
+++ b/src/gptk-core.ts
@@ -43,8 +43,7 @@ export default class Core {
       toTrash: async (p) => this.apiUtils.moveToTrash(p.mediaItems),
       removeFromAlbum: async (p) => {
         if (p.source !== 'albums') {
-          log('Remove from album requires the Albums source', 'error');
-          return;
+          throw new Error('Remove from album requires the Albums source');
         }
         await this.apiUtils.removeFromAlbum(p.mediaItems);
       },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,7 @@ export interface MediaItem {
   saved?: boolean;
   sourceAlbumMediaKey?: string;
   sourceAlbumTitle?: string;
+  sourceAlbumIsShared?: boolean;
   descriptionFull?: string;
   fileName?: string;
   size?: number;

--- a/src/ui/logic/action-bar.ts
+++ b/src/ui/logic/action-bar.ts
@@ -5,11 +5,13 @@ import { generateFilterDescription } from './filter-description-gen';
 import { updateUI } from './update-state';
 import { disableActionBar } from './utils/disable-action-bar';
 import getFromStorage from '../../utils/getFromStorage';
+import log from './log';
 import type { Action, Album, ApiSettings, Filter, Source } from '../../types';
 
 const actions: Action[] = [
   { elementId: 'toExistingAlbum', targetId: 'existingAlbum' },
   { elementId: 'toNewAlbum', targetId: 'newAlbumName' },
+  { elementId: 'removeFromAlbum' },
   { elementId: 'toTrash' },
   { elementId: 'restoreTrash' },
   { elementId: 'toArchive' },
@@ -69,6 +71,11 @@ async function runAction(actionId: string): Promise<void> {
 
   const sourceInput = document.querySelector('input[name="source"]:checked');
   const source = (sourceInput?.id ?? 'library') as Source;
+
+  if (actionId === 'removeFromAlbum' && source !== 'albums') {
+    log('Remove from album requires the Albums source', 'error');
+    return;
+  }
 
   const filtersForm = document.querySelector<HTMLFormElement>('.filters-form');
   if (filtersForm && !filtersForm.checkValidity()) {

--- a/src/ui/logic/update-state.ts
+++ b/src/ui/logic/update-state.ts
@@ -57,6 +57,18 @@ export function updateUI(): void {
     setDisabled('lock', isActiveTab('lockedFolder'));
     setDisabled('unLock', !isActiveTab('lockedFolder'));
     setDisabled('copyDescFromOther', isActiveTab('trash'));
+
+    // Soft-disabled (not the `disabled` attribute) so the hint tooltip still
+    // shows on hover — browsers suppress title tooltips on disabled buttons.
+    const removeFromAlbumBtn = document.getElementById('removeFromAlbum') as HTMLButtonElement | null;
+    if (removeFromAlbumBtn) {
+      const albumsActive = isActiveTab('albums');
+      removeFromAlbumBtn.classList.toggle('not-applicable', !albumsActive);
+      removeFromAlbumBtn.setAttribute('aria-disabled', String(!albumsActive));
+      removeFromAlbumBtn.title = albumsActive
+        ? 'Remove items from their album'
+        : 'Source must be Albums to remove items from an album';
+    }
   }
 
   function updateFilterVisibility(): void {

--- a/src/ui/markup/gptk-main-template.html
+++ b/src/ui/markup/gptk-main-template.html
@@ -291,6 +291,7 @@
         <div class="action-buttons">
           <button id="showExistingAlbumForm" title="Add To Existing Album">Add to Album</button>
           <button id="showNewAlbumForm" title="Add To New Album">New Album</button>
+          <button type="button" id="removeFromAlbum" title="Remove items from their album (Albums source only)">Remove from Album</button>
           <button type="button" id="toTrash" title="Move To Trash">Trash</button>
           <button type="button" id="restoreTrash" title="Restore From Trash">Restore</button>
           <button type="button" id="toArchive" title="Archive">Archive</button>

--- a/src/ui/markup/style.css
+++ b/src/ui/markup/style.css
@@ -186,7 +186,7 @@
         outline-offset: 1px;
     }
 
-    button:disabled {
+    button:disabled, button.not-applicable {
         background-color: var(--bg-raised);
         color: var(--text-disabled);
         border-color: transparent;

--- a/src/ui/markup/style.css
+++ b/src/ui/markup/style.css
@@ -171,12 +171,12 @@
         }
     }
 
-    button:not(:disabled):hover {
+    button:not(:disabled):not(.not-applicable):hover {
         background-color: var(--bg-surface-hover);
         border-color: var(--border-strong);
     }
 
-    button:not(:disabled):active {
+    button:not(:disabled):not(.not-applicable):active {
         background-color: var(--bg-surface-active);
         transform: scale(0.97);
     }

--- a/tests/album-shared-status.test.ts
+++ b/tests/album-shared-status.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// gptk-core transitively imports windowGlobalData (reads Tampermonkey `unsafeWindow`);
+// getFromStorage reads localStorage. Stub both so the module loads under Node.
+vi.mock('../src/windowGlobalData', () => ({ windowGlobalData: {} }));
+vi.mock('../src/utils/getFromStorage', () => ({ default: vi.fn(() => null) }));
+
+import Core from '../src/gptk-core';
+import type { Filter, Source } from '../src/types';
+
+describe('Core albums source shared-status resolution', () => {
+  it('fetches albums to resolve shared status when the cache is unavailable', async () => {
+    const core = new Core();
+    core.isProcessRunning = true;
+
+    const getAllAlbums = vi.fn().mockResolvedValue([{ mediaKey: 'ALB', isShared: true }]);
+    const getAllMediaInAlbumWithContext = vi.fn().mockResolvedValue({
+      title: 'Shared Album',
+      items: [{ mediaKey: 'item1', dedupKey: 'd1', timestamp: 0, creationTimestamp: 0 }],
+    });
+    core.apiUtils = { getAllAlbums, getAllMediaInAlbumWithContext } as unknown as Core['apiUtils'];
+
+    const items = await core.fetchMediaItems('albums' as Source, { albumsInclude: 'ALB' } as Filter);
+
+    // Cache was null, so the album list must be fetched to resolve shared status.
+    expect(getAllAlbums).toHaveBeenCalledTimes(1);
+    expect(items).toHaveLength(1);
+    expect(items[0].sourceAlbumIsShared).toBe(true);
+  });
+});

--- a/tests/remove-from-album.test.ts
+++ b/tests/remove-from-album.test.ts
@@ -42,4 +42,34 @@ describe('ApiUtils.removeFromAlbum', () => {
 
     expect(spy).not.toHaveBeenCalled();
   });
+
+  it('routes shared-album items to removeItemsFromSharedAlbum', async () => {
+    const core = { isProcessRunning: true } as unknown as Core;
+    const apiUtils = new ApiUtils(core, settings);
+    const regular = vi.spyOn(apiUtils.api, 'removeItemsFromAlbum').mockResolvedValue([]);
+    const shared = vi.spyOn(apiUtils.api, 'removeItemsFromSharedAlbum').mockResolvedValue([]);
+
+    await apiUtils.removeFromAlbum([
+      { ...makeItem('a'), sourceAlbumMediaKey: 'ALB', sourceAlbumIsShared: true },
+      { ...makeItem('b'), sourceAlbumMediaKey: 'ALB', sourceAlbumIsShared: true },
+    ]);
+
+    expect(regular).not.toHaveBeenCalled();
+    expect(shared).toHaveBeenCalledWith('ALB', ['a', 'b']);
+  });
+
+  it('routes each source album to the matching RPC', async () => {
+    const core = { isProcessRunning: true } as unknown as Core;
+    const apiUtils = new ApiUtils(core, settings);
+    const regular = vi.spyOn(apiUtils.api, 'removeItemsFromAlbum').mockResolvedValue([]);
+    const shared = vi.spyOn(apiUtils.api, 'removeItemsFromSharedAlbum').mockResolvedValue([]);
+
+    await apiUtils.removeFromAlbum([
+      { ...makeItem('a'), sourceAlbumMediaKey: 'REG', sourceAlbumIsShared: false },
+      { ...makeItem('s'), sourceAlbumMediaKey: 'SHARED', sourceAlbumIsShared: true },
+    ]);
+
+    expect(regular).toHaveBeenCalledWith(['a']);
+    expect(shared).toHaveBeenCalledWith('SHARED', ['s']);
+  });
 });

--- a/tests/remove-from-album.test.ts
+++ b/tests/remove-from-album.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// api-utils transitively imports windowGlobalData, which reads the Tampermonkey
+// `unsafeWindow` global at module load. Stub it so the module loads under Node.
+vi.mock('../src/windowGlobalData', () => ({ windowGlobalData: {} }));
+
+import ApiUtils from '../src/api/api-utils';
+import type Core from '../src/gptk-core';
+import type { ApiSettings, MediaItem } from '../src/types';
+
+function makeItem(mediaKey: string): MediaItem {
+  return { mediaKey, dedupKey: `dedup-${mediaKey}`, timestamp: 0, creationTimestamp: 0 };
+}
+
+const settings: ApiSettings = {
+  maxConcurrentSingleApiReq: 1,
+  maxConcurrentBatchApiReq: 3,
+  operationSize: 2,
+  lockedFolderOpSize: 100,
+  infoSize: 5000,
+};
+
+describe('ApiUtils.removeFromAlbum', () => {
+  it('removes items using their album-scoped mediaKey, chunked by operationSize', async () => {
+    const core = { isProcessRunning: true } as unknown as Core;
+    const apiUtils = new ApiUtils(core, settings);
+    const spy = vi.spyOn(apiUtils.api, 'removeItemsFromAlbum').mockResolvedValue([]);
+
+    await apiUtils.removeFromAlbum([makeItem('a'), makeItem('b'), makeItem('c')]);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, ['a', 'b']);
+    expect(spy).toHaveBeenNthCalledWith(2, ['c']);
+  });
+
+  it('does nothing for an empty selection', async () => {
+    const core = { isProcessRunning: true } as unknown as Core;
+    const apiUtils = new ApiUtils(core, settings);
+    const spy = vi.spyOn(apiUtils.api, 'removeItemsFromAlbum').mockResolvedValue([]);
+
+    await apiUtils.removeFromAlbum([]);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #65, #23.

## What
Adds a **Remove from Album** action that detaches selected items from their album **without trashing them** — surfacing the existing `removeItemsFromAlbum` RPC (previously only reachable via `gptkApi` in the console) as a proper UI action.

## How it works
- Runs from the **Albums** source (its items carry the album-scoped key the RPC needs).
- On any other source the button is greyed out with an explanatory tooltip and an early guard, so no library scan runs.
- Wired through `api-utils` → core action handler → action bar → template, following the existing action pattern.

## Testing
- Unit test for the batching/key logic; `typecheck`, `lint`, `test` (297 passing), and `build` all green.
- Manually verified against a live Google Photos account.

## Screenshots

**Albums source — action available (tooltip):**
<img width="1470" height="956" alt="Screenshot 2026-08-16 at 12 09 31 AM" src="https://github.com/user-attachments/assets/3f4d9c06-f9ec-4c9d-8cac-6e6e7aad68de" />


**Non-Albums source — guarded with tooltip "Source must be Albums…":**
<img width="1297" height="785" alt="Screenshot 2026-08-15 at 3 37 46 AM" src="https://github.com/user-attachments/assets/41e7b587-3f2f-4c2e-a114-e84a6316cf40" />


**Confirmation: How the full filter summary before running:**
<img width="1470" height="956" alt="Screenshot 2026-08-16 at 12 09 40 AM" src="https://github.com/user-attachments/assets/8ac633ab-0acd-468e-8f12-8cecc1e1896b" />


**Result — album filtered 5 → 1 by filename regex, removed, clean completion:**
<img width="1470" height="956" alt="Screenshot 2026-08-16 at 12 09 52 AM" src="https://github.com/user-attachments/assets/883a2c6b-3a19-4758-8de5-8bbdb807a34e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added a “Remove from Album” action for selected media in the Albums tab.
* Supports large selections through batched processing and album-specific media identifiers.
* Handles removal from both regular and shared albums.
* Provides contextual guidance and inactive styling when unavailable.

## Bug Fixes

* Prevented the action from running outside the Albums tab.
* Added safeguards for empty selections and invalid action contexts.
* Correctly identifies shared albums when cached information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->