### PR TITLE
chore: fix lint and formatting warnings

### DIFF
--- a/src/api/parser.ts
+++ b/src/api/parser.ts
@@ -115,8 +115,8 @@ function albumParse(itemData: any): Album {
     creationTimestamp: itemData?.at(-1)?.[72930366]?.[2]?.[4],
     modifiedTimestamp: itemData?.at(-1)?.[72930366]?.[2]?.[9],
     timestampRange: [itemData?.at(-1)?.[72930366]?.[2]?.[5], itemData?.at(-1)?.[72930366]?.[2]?.[6]],
-    isShared: itemData?.at(-1)?.[72930366]?.[4] || false,
-    authKey: itemData?.at(-1)?.[72930366]?.[5] || undefined,
+    isShared: itemData?.at(-1)?.[72930366]?.[4] ?? false,
+    authKey: itemData?.at(-1)?.[72930366]?.[5] ?? undefined,
   };
 }
 
@@ -258,7 +258,7 @@ function itemInfoExtParse(itemData: any): ItemInfoExt {
 
   let owner: Actor | null = null;
   if (itemData[0]?.[27]?.length > 0) {
-    owner = actorParse(itemData[0]?.[27]?.[3]?.[0] || itemData[0]?.[27]?.[4]?.[0]);
+    owner = actorParse(itemData[0]?.[27]?.[3]?.[0] ?? itemData[0]?.[27]?.[4]?.[0]);
   }
   if (!owner?.actorId) {
     owner = actorParse(itemData[0]?.[28]);
@@ -283,7 +283,7 @@ function itemInfoExtParse(itemData: any): ItemInfoExt {
     savedToYourPhotos: itemData[0]?.[12].filter((subArray: any[]) => subArray.includes(20)).length === 0,
     owner,
     geoLocation: {
-      coordinates: itemData[0]?.[9]?.[0] || itemData[0]?.[13]?.[0],
+      coordinates: itemData[0]?.[9]?.[0] ?? itemData[0]?.[13]?.[0],
       name: itemData[0]?.[13]?.[2]?.[0]?.[1]?.[0]?.[0],
       mapThumb: itemData?.[1],
     },

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -448,7 +448,7 @@ export async function filterSimilar(core: Core, mediaItems: MediaItem[], filter:
 
   log('Grouping similar images');
   const groups = await groupSimilarImages(
-    itemsWithHashes as HashedMediaItem[],
+    itemsWithHashes,
     similarityThreshold,
     hashSize,
     core

--- a/src/ui/logic/update-state.ts
+++ b/src/ui/logic/update-state.ts
@@ -20,7 +20,7 @@ export function updateUI(): void {
     const previewElement = document.querySelector('.filter-preview span');
     if (!previewElement) return;
     try {
-      const description = generateFilterDescription(getFormData('.filters-form') as unknown as Filter);
+      const description = generateFilterDescription(getFormData('.filters-form'));
       previewElement.textContent = description;
     } catch {
       previewElement.textContent = 'Failed to generate description';


### PR DESCRIPTION
## Summary

- use nullish fallbacks where ESLint requires them
- remove two redundant type assertions
- apply the repository's configured ESLint formatting rules

## Validation

- pnpm lint:fix
- pnpm lint
- pnpm typecheck
- pnpm test: 300 tests passed
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of valid empty, zero, and false values when importing album, ownership, and location data.
  - Preserved accurate fallback behavior when data is missing or unavailable.

- **Refactor**
  - Simplified internal data handling without changing the user-facing behavior of filtering or filter previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->