### PR TITLE
Release 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "google-photos-toolkit",
   "nameFull": "Google Photos Toolkit",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Bulk organize your media",
   "userScript": {
     "namespace": "https://github.com/xob0t/Google-Photos-Toolkit",


### PR DESCRIPTION
## Summary

- bump Google Photos Toolkit from 3.2.0 to 3.3.0

## Included since 3.2.0

- parse additional album and item metadata
- add Remove from Album support
- update development dependencies and clear lint warnings
- enforce linting in release builds

## Validation

- pnpm install --frozen-lockfile --strict-peer-dependencies
- pnpm lint
- pnpm typecheck
- pnpm test: 300 tests passed
- pnpm build: generated userscript reports version 3.3.0
- pnpm audit --prod=false: no known vulnerabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application to version 3.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->